### PR TITLE
Security Fix for Directory Traversal - huntr.dev

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,6 +85,10 @@ const writeFileContents = (res, path, dotCommand) => {
     path = '/';
   }
   try {
+
+    if(!path.startsWith('/'))
+      path = process.cwd() + path.replace(/(\.\.)/g, '');
+
     let contents = fs.readFileSync(path);
     res.writeHead(200);
     return res.end(contents);
@@ -108,6 +112,10 @@ const writeFileInfo = (res, path) => {
     path = '/';
   }
   try {
+
+    if(!path.startsWith('/'))
+      path = process.cwd() + path.replace(/(\.\.)/g, '');
+
     let stats = fs.statSync(path);
     res.writeHead(200);
     return res.end(JSON.stringify(stats));
@@ -121,6 +129,10 @@ const writeDirFiles = (res, path) => {
   if (path == '') {
     path = '/';
   }
+
+  if(!path.startsWith('/'))
+    path = process.cwd() + path.replace(/(\.\.)/g, '');
+  
   res.writeHead(200, {'Content-Type': 'text/plain'});
   return res.end(JSON.stringify(getDirFiles(path)));
 }


### PR DESCRIPTION
https://huntr.dev/users/Mik317 has fixed the Directory Traversal vulnerability 🔨. Mik317 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/nodejs-static-server/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/aso-server/1/README.md

### User Comments:

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-aso-server

### ⚙️ Description *

The `nodejs-static-server` module suffered of a `path traversal` issue which occurred when the attacker used the `double dot` technique requesting `relative` files, using the following `server syntax`:

`http://<server>:<port>/f/<payload>`

While, as per documentation (https://github.com/Mik317/nodejs-static-server/blob/master/README.md), `http://<server>:<port>/f//<file>` resolves also the `absolute files`, the `relative` syntax shouldn't be able to get files which are under the `server root`.

The same logic is applicable for every one of the `actions`, which are identified with the `f`,`d` and `i` characters.

### 💻 Technical Description *

Since I had to maintain the possibility to request `global files` using the right and documented syntax, and in the meanwhile, restrict the access to `relative` files only when using the `relative syntax`, I simply added a check which controls if the `syntax` is `relative` or `absolute` (`!path.startsWith('/')` stands for "absolute syntax not used" == "relative one used").

In case the `relative` request is caught by the server, the `double dots` are deleted and the original path is `concatenated` with the `process.cwd()` path, which makes possible requesting only `relative` files (so, files under the same directory where the server had been started).

### 🐛 Proof of Concept (PoC) *

The POC is here: https://github.com/JacksonGL/NPM-Vuln-PoC/tree/master/directory-traversal/aso-server

![Screenshot from 2020-09-01 12-40-51](https://user-images.githubusercontent.com/33063403/91842633-b10c4200-ec54-11ea-8ef9-b2d1eb72be1f.png)

### 🔥 Proof of Fix (PoF) *

* The fixed `relative` doesn't show the `absolute file` anymore:
![Screenshot from 2020-09-01 12-51-14](https://user-images.githubusercontent.com/33063403/91842652-bbc6d700-ec54-11ea-8308-e7d44e1507e3.png)

* The `absolute path` still works, as it is a feature documented in the README:
![Screenshot from 2020-09-01 12-54-05](https://user-images.githubusercontent.com/33063403/91842712-d26d2e00-ec54-11ea-864c-db15002a0d8f.png)

### 👍 User Acceptance Testing (UAT)

All ok :+1: 